### PR TITLE
Strip 'use strict' if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ function convert (source, options) {
             throw new Error('Dynamic module names are not supported.');
         }
 
+        if (isUseStrict(node)) {
+          node.parent.update('');
+        }
+
     });
 
     // no module definition found - return source untouched
@@ -338,4 +342,13 @@ function isDefineUsingIdentifier(node) {
  */
 function makeImportName (moduleName) {
     return '$__' + moduleName.replace(/-/g, '_').replace(/\//g, '_');
+}
+
+/**
+ * Returns true if node represents a 'use strict'-statement
+ * @param {object} node
+ * @returns {boolean}
+ */
+function isUseStrict (node) {
+    return node.type === 'Literal' && node.value === 'use strict';
 }

--- a/test/examples/use-strict-expected.js
+++ b/test/examples/use-strict-expected.js
@@ -1,0 +1,1 @@
+export default 'something';

--- a/test/examples/use-strict.js
+++ b/test/examples/use-strict.js
@@ -1,0 +1,6 @@
+define(function () {
+    'use strict';
+
+    return 'something';
+
+});

--- a/test/spec.js
+++ b/test/spec.js
@@ -18,6 +18,7 @@ makeTest('define-no-deps');
 makeTest('require-with-deps');
 makeTest('require-no-deps');
 makeTest('inline-sync-requires');
+makeTest('use-strict');
 
 var makeErrorCaseTest = function (name, message) {
 


### PR DESCRIPTION
`use strict` is default in ES6, so I'm thinking this does not have to be behind a flag. https://babeljs.io/docs/advanced/transformers/other/strict/

No idea if this is the way to do it, and it's also kept if the source is returned early.

This is probably not ready for merge, as I just hacked something together that works for my project, not necessarily the best way to do it 