### PR TITLE
replace period and exclamation marks used in the require.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,5 +342,5 @@ function isDefineUsingIdentifier(node) {
  * @returns {string}
  */
 function makeImportName (moduleName) {
-    return '$__' + moduleName.replace(/-/g, '_').replace(/\//g, '_');
+    return '$__' + moduleName.replace(/-/g, '_').replace(/\//g, '_').replace(/\./g, '_').replace(/\!/g, '_');
 }


### PR DESCRIPTION
requirejs plugin syntax uses the following dynamic loader syntax
example:  require('css/css!./TextBox.css')

for this to be a valid import variable name, we need to replace these signs



