### PR TITLE
Adds support for arrow functions in input files

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,8 +303,18 @@ function isModuleDefinition (node) {
         return true;
     }
 
+    // eg. require(['a', 'b'], () => {})
+    if (arrayEquals(argTypes, ['ArrayExpression', 'ArrowFunctionExpression'])) {
+        return true;
+    }
+
     // eg. require(function () {}) or define(function () {})
     if (arrayEquals(argTypes, ['FunctionExpression'])) {
+        return true;
+    }
+
+    // eg. require(() => {}) or define(() => {})
+    if (arrayEquals(argTypes, ['ArrowFunctionExpression'])) {
         return true;
     }
 }

--- a/test/examples/define-no-deps-arrow.js
+++ b/test/examples/define-no-deps-arrow.js
@@ -1,0 +1,5 @@
+define(() => {
+
+    return 'something';
+
+});

--- a/test/examples/define-with-deps-arrow.js
+++ b/test/examples/define-with-deps-arrow.js
@@ -1,0 +1,13 @@
+define([
+    'some/path/to/a',
+    'some/path/to/b',
+    'some/path/to/c'
+], (varNameForA, varNameForB) => {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+});

--- a/test/examples/dynamic-module-names-arrow.js
+++ b/test/examples/dynamic-module-names-arrow.js
@@ -1,0 +1,3 @@
+define(['a', 'b'], (a,b) => {
+    require(a.pathname);
+});

--- a/test/examples/inline-sync-requires-arrow.js
+++ b/test/examples/inline-sync-requires-arrow.js
@@ -1,0 +1,10 @@
+define(['a', 'b', 'css/css!./TextBox.css'], (a) => {
+
+    var b = require('b');
+    var c = require('css/css!./TextBox.css');
+
+    return function () {
+        a(b(c));
+    }
+
+});

--- a/test/examples/multiple-module-definitions-arrow.js
+++ b/test/examples/multiple-module-definitions-arrow.js
@@ -1,0 +1,9 @@
+define(() => {
+
+});
+
+require([
+    'some/thing'
+], (thing) => {
+
+});

--- a/test/examples/named-define-arrow.js
+++ b/test/examples/named-define-arrow.js
@@ -1,0 +1,3 @@
+define('module-name', () => {
+    return 'whatever';
+});

--- a/test/examples/nested-module-definitions-arrow.js
+++ b/test/examples/nested-module-definitions-arrow.js
@@ -1,0 +1,3 @@
+define(['a'], (a) => {
+    require([a.pathName]);
+});

--- a/test/examples/preserve-quotes-arrow.js
+++ b/test/examples/preserve-quotes-arrow.js
@@ -1,0 +1,5 @@
+define(["underscore", 'jquery'], (_, $) => {
+
+    return $(_);
+
+});

--- a/test/examples/require-no-deps-arrow.js
+++ b/test/examples/require-no-deps-arrow.js
@@ -1,0 +1,5 @@
+require(() => {
+
+    return 'something';
+
+});

--- a/test/examples/require-with-custom-loader-arrow.js
+++ b/test/examples/require-with-custom-loader-arrow.js
@@ -1,0 +1,13 @@
+require([
+    'css/css!./TextBox.css',
+    'some/path/to/b',
+    'some/path/to/c'
+], (someCSS) => {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+});

--- a/test/examples/require-with-deps-arrow.js
+++ b/test/examples/require-with-deps-arrow.js
@@ -1,0 +1,13 @@
+require([
+    'some/path/to/a',
+    'some/path/to/b',
+    'some/path/to/c'
+], (varNameForA, varNameForB) => {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+});

--- a/test/examples/umd-module-arrow.js
+++ b/test/examples/umd-module-arrow.js
@@ -1,0 +1,13 @@
+(function (root, factory) {
+
+    if (typeof define === 'function' && define.amd) {
+        define(['jquery'], factory);
+    } else {
+        root.components = factory();
+    }
+
+}(this, (jQuery) => {
+
+    return jQuery.version;
+
+}));

--- a/test/examples/use-strict-arrow.js
+++ b/test/examples/use-strict-arrow.js
@@ -1,0 +1,6 @@
+define(() => {
+    'use strict';
+
+    return 'something';
+
+});

--- a/test/spec.js
+++ b/test/spec.js
@@ -7,10 +7,18 @@ var readFile = function (name) {
 
 var makeTest = function (name) {
 
-    exports['test ' + name.replace(/-/g, ' ')] = function (test) {
-        test.equal(amdToEs6(readFile(name), {beautify: true}), readFile(name + '-expected'));
-        test.done();
+    var baseTestName = 'test ' + name.replace(/-/g, ' ');
+    var expectedOutputFileName = readFile(name.replace(/-arrow$/, '') + '-expected');
+
+    var makeTestCase = function (inputFilename) {
+        return function (test) {
+            test.equal(amdToEs6(readFile(inputFilename), {beautify: true}), expectedOutputFileName);
+            test.done();
+        };        
     };
+
+    exports[baseTestName] = makeTestCase(name);
+    exports[baseTestName + ' (using arrow function)'] = makeTestCase(name + '-arrow');
 
 };
 makeTest('define-with-deps');
@@ -23,12 +31,19 @@ makeTest('use-strict');
 
 var makeErrorCaseTest = function (name, message) {
 
-    exports['test ' + name.replace(/-/g, ' ') + ' throws error'] = function (test) {
-        test.throws(function () {
-            amdToEs6(readFile(name));
-        }, new RegExp(message));
-        test.done();
+    var makeErrorCaseTest = function(inputFilename) {
+        return function (test) {
+            test.throws(function () {
+                amdToEs6(readFile(inputFilename));
+            }, new RegExp(message));
+            test.done();
+        };
     };
+
+    var baseTestName = 'test ' + name.replace(/-/g, ' ');
+
+    exports[baseTestName + ' throws error'] = makeErrorCaseTest(name);
+    exports[baseTestName + ' (using arrow function) throws error'] = makeErrorCaseTest(name + '-arrow');
 
 };
 makeErrorCaseTest('multiple-module-definitions', 'Found multiple module definitions in one file.');


### PR DESCRIPTION
Changes:
- Wherever FunctionExpressions (i.e. `function () {} `) were being parsed for previously, ArrowFunctionExpressions (i.e. `() => {}`) will also be supported. This is useful for files that are already written primarily in ES6+ but still want to convert their AMD modules to use ES6 modules.
- All test cases will now also look for a `*-arrow.js` file. Identical errors and output are expected for each test case’s new `*-arrow.js` source file.

Adds:
- Source files using arrow functions for all test cases