### PR TITLE
Upgrade ECMAScript version to 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 var os = require('os');
 var falafel = require('falafel');
-var acorn = require('acorn-jsx');
+var jsx = require('acorn-jsx');
+var acorn = require('acorn');
 var beautify = require('js-beautify').js_beautify;
 
 module.exports = convert;
+
+var JSXParser = acorn.Parser.extend(jsx());
 
 /**
  * Converts some code from AMD to ES6
@@ -21,9 +24,10 @@ function convert (source, options) {
     var mainCallExpression = null;
 
     var result = falafel(source, {
-        parser: acorn,
-        plugins: {jsx: true},
-        ecmaVersion: 6
+        parser: {
+            parse: JSXParser.parse.bind(JSXParser)
+        },
+        ecmaVersion: 9
     }, function (node) {
         if (isNamedDefine(node)) {
             throw new Error('Found a named define - this is not supported.');

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "test": "test"
   },
   "dependencies": {
-    "acorn-jsx": "^2.0.0",
+    "acorn": "^6.1.1",
+    "acorn-jsx": "^5.0.1",
     "commander": "^2.4.0",
-    "falafel": "~1.2.0",
+    "falafel": "^2.1.0",
     "glob": "^4.0.6",
     "js-beautify": "~1.5.1",
     "mkdirp": "^0.5.0"

--- a/test/examples/async-await-arrow.js
+++ b/test/examples/async-await-arrow.js
@@ -1,0 +1,18 @@
+define([
+    'some/path/to/a',
+    'some/path/to/b',
+    'some/path/to/c'
+], (varNameForA, varNameForB) => {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+    async function x () {}
+
+    async function y () {
+        await x();
+    }
+});

--- a/test/examples/async-await-expected.js
+++ b/test/examples/async-await-expected.js
@@ -1,0 +1,15 @@
+import varNameForA from 'some/path/to/a';
+import varNameForB from 'some/path/to/b';
+import 'some/path/to/c';
+
+// do something with dep A
+varNameForA();
+
+// do something with dep B
+varNameForB();
+
+async function x() {}
+
+async function y() {
+    await x();
+}

--- a/test/examples/async-await.js
+++ b/test/examples/async-await.js
@@ -1,0 +1,18 @@
+define([
+    'some/path/to/a',
+    'some/path/to/b',
+    'some/path/to/c'
+], function (varNameForA, varNameForB) {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+    async function x () {}
+
+    async function y () {
+        await x();
+    }
+});

--- a/test/examples/rest-object-arrow.js
+++ b/test/examples/rest-object-arrow.js
@@ -1,0 +1,15 @@
+define([
+    'some/path/to/a',
+    'some/path/to/b',
+    'some/path/to/c'
+], (varNameForA, varNameForB) => {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+    var a = { foo: 1 };
+    var b = { ...a, bar: 2 };
+});

--- a/test/examples/rest-object-expected.js
+++ b/test/examples/rest-object-expected.js
@@ -1,0 +1,15 @@
+import varNameForA from 'some/path/to/a';
+import varNameForB from 'some/path/to/b';
+import 'some/path/to/c';
+
+// do something with dep A
+varNameForA();
+
+// do something with dep B
+varNameForB();
+
+var a = {
+    foo: 1
+};
+var b = {...a, bar: 2
+};

--- a/test/examples/rest-object.js
+++ b/test/examples/rest-object.js
@@ -1,0 +1,15 @@
+define([
+    'some/path/to/a',
+    'some/path/to/b',
+    'some/path/to/c'
+], function (varNameForA, varNameForB) {
+
+    // do something with dep A
+    varNameForA();
+
+    // do something with dep B
+    varNameForB();
+
+    var a = { foo: 1 };
+    var b = { ...a, bar: 2 };
+});

--- a/test/spec.js
+++ b/test/spec.js
@@ -28,6 +28,8 @@ makeTest('require-no-deps');
 makeTest('inline-sync-requires');
 makeTest('preserve-quotes');
 makeTest('use-strict');
+makeTest('async-await');
+makeTest('rest-object');
 
 var makeErrorCaseTest = function (name, message) {
 


### PR DESCRIPTION
Support modern syntax.
Tested with object rest spread operator (`...`) and `async`/`await` syntax.
Fixes #32 